### PR TITLE
Fixed error for German Umlaut

### DIFF
--- a/wit/wit.py
+++ b/wit/wit.py
@@ -87,7 +87,7 @@ class Wit:
         if rst['type'] == 'msg':
             if 'say' not in self.actions:
                 raise WitError('unknown action: say')
-            self.logger.info('Executing say with: {}'.format(rst['msg']))
+            self.logger.info('Executing say with: {}'.format(rst['msg'].encode('utf8')))
             self.actions['say'](session_id, dict(context), rst['msg'])
         elif rst['type'] == 'merge':
             if 'merge' not in self.actions:


### PR DESCRIPTION
When Bot say action contain an German umlaut, an error is thrown:

> UnicodeEncodeError: 'ascii' codec can't encode character u'\xf6' in position 31: ordinal not in range(128)