### PR TITLE
Inheriting Wit class from object to enable subclassing in python2.7

### DIFF
--- a/wit/wit.py
+++ b/wit/wit.py
@@ -55,7 +55,7 @@ def validate_actions(logger, actions):
                             '\' action should be a function.')
     return actions
 
-class Wit:
+class Wit(object):
     access_token = None
     actions = {}
     _sessions = {}


### PR DESCRIPTION
Since `Wit`  does not inherit from `object` it was not possible to subclass from it. 
Inheriting `Wit` from `object` now.