### PR TITLE
message: Add thread_id parameter

### DIFF
--- a/wit/wit.py
+++ b/wit/wit.py
@@ -66,7 +66,7 @@ class Wit(object):
         if actions:
             self.actions = validate_actions(self.logger, actions)
 
-    def message(self, msg, context=None, verbose=None):
+    def message(self, msg, context=None, verbose=None, thread_id=None):
         params = {}
         if verbose:
             params['verbose'] = True
@@ -74,6 +74,8 @@ class Wit(object):
             params['q'] = msg
         if context:
             params['context'] = json.dumps(context)
+        if thread_id:
+            params['thread_id'] = str(thread_id)  # Might be an int
         resp = req(self.logger, self.access_token, 'GET', '/message', params)
         return resp
 


### PR DESCRIPTION
See https://wit.ai/docs/http/20160330#get-intent-via-text-link

I'm not fully sure what wit does with the thread_id but AFAIK the results are supposed to get better since it can take the rest of the conversation into account? I'd also suggest improving that doc linked above to include - same for context.