### PR TITLE
FIX: session id now being passed in context

### DIFF
--- a/examples/messenger.py
+++ b/examples/messenger.py
@@ -77,7 +77,7 @@ def messenger_post():
                 text = message['message']['text']
                 # Let's forward the message to Wit /message
                 # and customize our response to the message in handle_message
-                response = client.message(msg=text, session_id=fb_id)
+                response = client.message(msg=text, context={'session_id':fb_id})
                 handle_message(response=response, fb_id=fb_id)
     else:
         # Returned another event


### PR DESCRIPTION
The session_id param was being passed raw when it's supposed to be passed as a key/value pair in a python dictionary. 

I've tested this on messenger myself and it works.

![screen shot 2018-02-15 at 11 44 10 pm](https://user-images.githubusercontent.com/4019054/36293820-2b613ed4-12aa-11e8-9b06-d2771533ec28.png)
