### PR TITLE
Set prompt_toolkit version. (2.0.0 has breaking changes).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from distutils.command.build_py import build_py
 
-install_requires = ['prompt_toolkit']
+install_requires = ['prompt_toolkit>=1.0.15,<2.0.0']
 if sys.version_info < (2, 6):
     warnings.warn(
         'Python 2.5 is no longer officially supported by Wit. '


### PR DESCRIPTION
I will probably release prompt_toolkit 2.0 this or next week, and it has breaking changes, so it'd be good to merge this. After the release we can still upgrade.