### PR TITLE
Update req method to support JSON errors

### DIFF
--- a/wit/wit.py
+++ b/wit/wit.py
@@ -38,9 +38,9 @@ def req(logger, access_token, meth, path, params, **kwargs):
         params=params,
         **kwargs
     )
-    if rsp.status_code > 200:
-        raise WitError('Wit responded with status: ' + str(rsp.status_code) +
-                       ' (' + rsp.reason + ')')
+    #if rsp.status_code > 200:
+    #    raise WitError('Wit responded with status: ' + str(rsp.status_code) +
+    #                   ' (' + rsp.reason + ')')
     json = rsp.json()
     if 'error' in json:
         raise WitError('Wit responded with an error: ' + json['error'])


### PR DESCRIPTION
The removed piece of code raises an error with request code which disallows the client from giving you the error information in JSON.
By removing this, it will raise an error with description, more efficient than ERROR 400.