### PR TITLE
feat: add optional 'tag' parameter to message()

### DIFF
--- a/wit/wit.py
+++ b/wit/wit.py
@@ -54,7 +54,7 @@ class Wit:
         self.access_token = access_token
         self.logger = logger or logging.getLogger(__name__)
 
-    def message(self, msg, context=None, n=None, verbose=None):
+    def message(self, msg, context=None, n=None, verbose=None, tag=None):
         params = {}
         if n is not None:
             params["n"] = n
@@ -64,6 +64,8 @@ class Wit:
             params["context"] = json.dumps(context)
         if verbose:
             params["verbose"] = verbose
+        if tag:
+            params["tag"] = tag
         resp = req(self.logger, self.access_token, "GET", "/message", params)
         return resp
 


### PR DESCRIPTION
### Summary

Added an optional `tag` parameter to the `message()` method to support multiple app versions when making requests to the Wit.ai API.

This makes it easier to specify which version (tag) of the app the message should be evaluated against.

### Changes

- Updated `message()` in `wit.py` to accept a `tag` argument.
- If provided, `tag` is added to the request params.

### Use Case

I have multiple versions of my app on Wit.ai, and this change allows me to direct queries to a specific version using the `tag` parameter. This helps in testing and deploying versioned NLP models without modifying core logic.

### Related Issue

Fixes #167

---

Let me know if anything else needs tweaking!
